### PR TITLE
Fixed player and bob movements with momentum disabled

### DIFF
--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -155,19 +155,6 @@ class PlayerPawn : Actor
 			}
 		}
 		Super.Tick();
-
-
-        //Taken from the Wolf-3D TC - Prevent player having momentum/acceleration to avoid puking
-		CVar vr_momentum = CVar.FindCVar("vr_momentum");
-		if ((!vr_momentum || !vr_momentum.GetInt()) && pos.z == floorz)
-		{
-			vel *= 0;
-			Speed = Default.Speed * 8;
-		}
-		else
-		{
-			Speed = Default.Speed;
-		}
 	}
 
 	//===========================================================================
@@ -1276,6 +1263,20 @@ class PlayerPawn : Actor
 
 		player.onground = (pos.z <= floorz + 0.1) || bOnMobj || bMBFBouncer || (player.cheats & CF_NOCLIP2);
 
+		double friction, movefactor;
+		[friction, movefactor] = GetFriction();
+		CVar vr_momentum = CVar.FindCVar("vr_momentum");
+		//Taken from the Wolf-3D TC - Prevent player having momentum/acceleration to avoid puking
+		if ((!vr_momentum || !vr_momentum.GetInt()) && player.onground && friction == ORIG_FRICTION)
+		{
+			vel *= 0.0001;
+			Speed = Default.Speed * 8;
+		}
+		else
+		{
+			Speed = Default.Speed;
+		}
+
 		// killough 10/98:
 		//
 		// We must apply thrust to the player and bobbing separately, to avoid
@@ -1287,10 +1288,8 @@ class PlayerPawn : Actor
 		{
 			double forwardmove, sidemove;
 			double bobfactor;
-			double friction, movefactor;
 			double fm, sm;
 
-			[friction, movefactor] = GetFriction();
 			bobfactor = friction < ORIG_FRICTION ? movefactor : ORIG_FRICTION_FACTOR;
 			if (!player.onground && !bNoGravity && !waterlevel)
 			{


### PR DESCRIPTION
- fixed movement too slow on ice and muddy surface with slidey movement (Momentum) disabled
- fixed constant bob movement with slidey movement (Momentum) disabled

The velocity will not be zeroed when the player moves on muddy or icy surface, this will retain the original mechanic of momentum and also fix the slow speed when on surface with friction different from the default.

resolve DrBeef/QuestZDoom#9