### PR TITLE
Enable player bob movement and disable weapon bob

### DIFF
--- a/src/d_netinfo.cpp
+++ b/src/d_netinfo.cpp
@@ -70,7 +70,7 @@ CVAR (String,	skin,					"base",		CVAR_USERINFO | CVAR_ARCHIVE);
 CVAR (Int,		team,					TEAM_NONE,	CVAR_USERINFO | CVAR_ARCHIVE);
 CVAR (String,	gender,					"male",		CVAR_USERINFO | CVAR_ARCHIVE);
 CVAR (Bool,		neverswitchonpickup,	false,		CVAR_USERINFO | CVAR_ARCHIVE);
-CVAR (Float,	movebob,				0.25f,		CVAR_USERINFO | CVAR_ARCHIVE);
+CVAR (Float,	movebob,				0.f,		CVAR_USERINFO | CVAR_ARCHIVE);
 CVAR (Float,	stillbob,				0.f,		CVAR_USERINFO | CVAR_ARCHIVE);
 CVAR (Float,	wbobspeed,				1.f,		CVAR_USERINFO | CVAR_ARCHIVE);
 CVAR (Float,	wbobfire,				0.f,		CVAR_USERINFO | CVAR_ARCHIVE);

--- a/src/gl/stereo3d/gl_oculusquest.cpp
+++ b/src/gl/stereo3d/gl_oculusquest.cpp
@@ -464,11 +464,6 @@ namespace s3d
 
         QzDoom_processMessageQueue();
 
-        // Set VR-appropriate settings
-        {
-            movebob = 0;
-        }
-
         if (gamestate == GS_LEVEL && getMenuState() == MENU_Off) {
             cachedScreenBlocks = screenblocks;
             screenblocks = 12;

--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -606,16 +606,16 @@ void P_BringUpWeapon (player_t *player)
 
 void P_BobWeapon (player_t *player, float *x, float *y, double ticfrac)
 {
-	IFVIRTUALPTRNAME(player->mo, NAME_PlayerPawn, BobWeapon)
-	{
-		VMValue param[] = { player->mo, ticfrac };
-		DVector2 result;
-		VMReturn ret(&result);
-		VMCall(func, param, 2, &ret, 1);
-		*x = (float)result.X;
-		*y = (float)result.Y;
-		return;
-	}
+	// IFVIRTUALPTRNAME(player->mo, NAME_PlayerPawn, BobWeapon)
+	// {
+	// 	VMValue param[] = { player->mo, ticfrac };
+	// 	DVector2 result;
+	// 	VMReturn ret(&result);
+	// 	VMCall(func, param, 2, &ret, 1);
+	// 	*x = (float)result.X;
+	// 	*y = (float)result.Y;
+	// 	return;
+	// }
 	*x = *y = 0;
 }
 

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1042,7 +1042,6 @@ OptionMenu "HUDOptions" protected
 	StaticText " "
 	Slider "$DSPLYMNU_MOVEBOB",				"movebob", 0, 1.0, 0.05, 2
 	Slider "$DSPLYMNU_STILLBOB",			"stillbob", 0, 1.0, 0.05, 2
-	Slider "$DSPLYMNU_BOBSPEED",			"wbobspeed", 0, 2.0, 0.1
 	StaticText " "
 	Slider "$DSPLYMNU_MENUDIM",					"dimamount", 0, 1.0, 0.05, 2
 	ColorPicker "$DSPLYMNU_DIMCOLOR",			"dimcolor"


### PR DESCRIPTION
- Player bob movement can be changed again from the hud options
- Weapon bob has been disabled and options removed from the hud options

Previous pull request from @neodraig
https://github.com/DrBeef/QuestZDoom/pull/11